### PR TITLE
Added token unenroll and voiding/unvoiding of tokens.

### DIFF
--- a/block/block_course_tokens.php
+++ b/block/block_course_tokens.php
@@ -19,10 +19,11 @@ class block_course_tokens extends block_base
 
         // SQL query to fetch tokens associated with the logged-in user
         $sql = "SELECT t.*, u.email as enrolled_user_email
-                FROM {course_tokens} t
-                LEFT JOIN {user_enrolments} ue ON t.user_enrolments_id = ue.id
-                LEFT JOIN {user} u ON ue.userid = u.id
-                WHERE t.user_id = ?";
+            FROM {course_tokens} t
+            LEFT JOIN {user_enrolments} ue ON t.user_enrolments_id = ue.id
+            LEFT JOIN {user} u ON ue.userid = u.id
+            WHERE t.user_id = ? AND t.voided_at IS NULL
+            ORDER BY t.id DESC";
 
         // Execute the SQL query and get the tokens
         $tokens = $DB->get_records_sql($sql, [$USER->id]);

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,4 +1,4 @@
-<XMLDB PATH="enrol/course_tokens/db" VERSION="2024120304" COMMENT="XMLDB file for Moodle enrol/course_tokens"
+<XMLDB PATH="enrol/course_tokens/db" VERSION="2024120305" COMMENT="XMLDB file for Moodle enrol/course_tokens"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd">
   <TABLES>
@@ -9,7 +9,9 @@
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true"/>
         <FIELD NAME="code" TYPE="char" LENGTH="50" NOTNULL="true"/>
         <FIELD NAME="course_id" TYPE="int" LENGTH="10" NOTNULL="true"/>
-        <FIELD NAME="voided" TYPE="binary" LENGTH="1" NOTNULL="true"/> 
+        <FIELD NAME="voided" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0"/>
+        <FIELD NAME="voided_at" TYPE="int" LENGTH="10" NOTNULL="false"/> 
+        <FIELD NAME="voided_notes" TYPE="text" NOTNULL="false"/>
         <FIELD NAME="user_enrolments_id" TYPE="int" LENGTH="10" NOTNULL="false"/>
         <FIELD NAME="extra_json" TYPE="text" NOTNULL="false"/>
         <FIELD NAME="user_id" TYPE="int" LENGTH="10" NOTNULL="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -5,82 +5,37 @@ function xmldb_enrol_course_tokens_upgrade($oldversion) {
     global $DB;
 
     $dbman = $DB->get_manager();
-
-    if ($oldversion < 2024120304) {
-        // Define table course_tokens to be created
+    
+    // Upgrade to version 2024120305: Add voided_at and voided_notes fields.
+    if ($oldversion < 2024120305) {
         $table = new xmldb_table('course_tokens');
 
-        // Adding fields to table course_tokens
-        $table->addField(new xmldb_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null));
-        $table->addField(new xmldb_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null));
-        $table->addField(new xmldb_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null));
-        $table->addField(new xmldb_field('code', XMLDB_TYPE_CHAR, '50', null, XMLDB_NOTNULL, null, null));
-        $table->addField(new xmldb_field('course_id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null));
-        $table->addField(new xmldb_field('voided', XMLDB_TYPE_BINARY, '1', null, XMLDB_NOTNULL, null, '0'));
-        $table->addField(new xmldb_field('user_enrolments_id', XMLDB_TYPE_INTEGER, '10', null, null, null, null));
-        $table->addField(new xmldb_field('extra_json', XMLDB_TYPE_TEXT, null, null, null, null, null));
-
-        // Add keys to the table
-        $table->addKey(new xmldb_key('primary', XMLDB_KEY_PRIMARY, array('id')));
-        $table->addKey(new xmldb_key('course_id_fk', XMLDB_KEY_FOREIGN, array('course_id'), 'course', array('id')));
-        $table->addKey(new xmldb_key('user_enrolments_id_fk', XMLDB_KEY_FOREIGN, array('user_enrolments_id'), 'user_enrolments', array('id')));
-
-        // Create table
-        if (!$dbman->table_exists($table)) {
-            $dbman->create_table($table);
+        // Add voided_at field if it does not exist.
+        if (!$dbman->field_exists($table, 'voided_at')) {
+            $voidedAtField = new xmldb_field('voided_at', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+            $dbman->add_field($table, $voidedAtField);
         }
 
-        // Enrolltokens savepoint reached
-        upgrade_plugin_savepoint(true, 2024120304, 'enrol', 'course_tokens');
+        // Add voided_notes field if it does not exist.
+        if (!$dbman->field_exists($table, 'voided_notes')) {
+            $voidedNotesField = new xmldb_field('voided_notes', XMLDB_TYPE_TEXT, null, null, null, null, null);
+            $dbman->add_field($table, $voidedNotesField);
+        }
+
+        // Upgrade savepoint.
+        upgrade_plugin_savepoint(true, 2024120305, 'enrol', 'course_tokens');
     }
 
-    if ($oldversion < 2024120304) {
-        $table = new xmldb_table('course_tokens');
-        
-        // Adding fields if they don't exist
-        if (!$dbman->field_exists($table, 'user_id')) {
-            $table->addField(new xmldb_field('user_id', XMLDB_TYPE_INTEGER, '10', null, null, null, null));
-            $dbman->add_field($table, new xmldb_field('user_id'));
-        }
-
-        if (!$dbman->field_exists($table, 'used_on')) {
-            $table->addField(new xmldb_field('used_on', XMLDB_TYPE_INTEGER, '10', null, null, null, null));
-            $dbman->add_field($table, new xmldb_field('used_on'));
-        }
-
-        // Adding foreign key if the field exists
-        if ($dbman->field_exists($table, 'user_id')) {
-            $table->addKey(new xmldb_key('user_id_fk', XMLDB_KEY_FOREIGN, array('user_id'), 'user', array('id')));
-        }
-
-        // Enrolltokens savepoint reached
-        upgrade_plugin_savepoint(true, 2024120305, 'enrol', 'course_tokens'); // This version needs to be one up.
-    }
-
-    if ($oldversion < 2024120304) { // Update for group_account and created_by
+    // Upgrade to version 2024120306: Change voided from longblob to tinyint(1).
+    if ($oldversion < 2024120306) {
         $table = new xmldb_table('course_tokens');
 
-        // Adding new fields
-        if (!$dbman->field_exists($table, 'group_account')) {
-            $table->addField(new xmldb_field('group_account', XMLDB_TYPE_CHAR, '255', null, null, null, null)); // Corporate Account
-            $dbman->add_field($table, new xmldb_field('group_account'));
-        }
+        // Check if voided is of incorrect type and change it.
+        $voidedField = new xmldb_field('voided', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0');
+        $dbman->change_field_type($table, $voidedField);
 
-        if (!$dbman->field_exists($table, 'created_by')) {
-            $table->addField(new xmldb_field('created_by', XMLDB_TYPE_INTEGER, '10', null, null, null, null)); // Created By
-            $dbman->add_field($table, new xmldb_field('created_by'));
-        }
-
-        if (!$dbman->field_exists($table, 'used_by')) {
-            $table->addField(new xmldb_field('used_by', XMLDB_TYPE_CHAR, '255', null, null, null, null)); // Used By
-            $dbman->add_field($table, new xmldb_field('used_by'));
-        }
-
-        // Add keys for new fields
-        $table->addKey(new xmldb_key('created_by_fk', XMLDB_KEY_FOREIGN, array('created_by'), 'user', array('id')));
-
-        // Enrolltokens savepoint reached
-        upgrade_plugin_savepoint(true, 2024120304, 'enrol', 'course_tokens');
+        // Upgrade savepoint.
+        upgrade_plugin_savepoint(true, 2024120306, 'enrol', 'course_tokens');
     }
 
     return true;

--- a/index.php
+++ b/index.php
@@ -194,6 +194,15 @@ foreach ($tokens as $token) {
     echo '<td>';
     echo '<button class="btn btn-secondary resend-email" data-email="' . s($purchaser_email) . '" data-token="' . s($token->code) . '">Resend New Account Email</button>';
     echo '</td>';
+    if (!empty($token->user_enrolments_id)) {
+        echo '<td><form action="unenroll.php" method="post">
+                <input type="hidden" name="token_id" value="' . s($token->id) . '">
+                <input type="hidden" name="sesskey" value="' . sesskey() . '">
+                <button type="submit" class="btn btn-danger">Unenroll</button>
+              </form></td>';
+    } else {
+        echo '<td>-</td>';
+    }
     echo '</tr>';
 }
 echo '</table>';

--- a/unenroll.php
+++ b/unenroll.php
@@ -3,19 +3,24 @@ require_once('../../config.php');
 require_login();
 require_capability('moodle/site:config', context_system::instance());
 
+// Set JSON header
+header('Content-Type: application/json');
+
 $token_id = required_param('token_id', PARAM_INT);
 $sesskey = required_param('sesskey', PARAM_ALPHANUM);
 
 if (!confirm_sesskey($sesskey)) {
-    print_error('invalidsesskey');
+    echo json_encode(['success' => false, 'message' => 'Invalid session key']);
+    exit;
 }
 
 // Call the unenroll function
 if (unenroll_user_by_token($token_id)) {
-    redirect(new moodle_url('/enrol/course_tokens/index.php'), 'User unenrolled successfully.', null, \core\output\notification::NOTIFY_SUCCESS);
+    echo json_encode(['success' => true, 'message' => 'User unenrolled successfully']);
 } else {
-    redirect(new moodle_url('/enrol/course_tokens/index.php'), 'Failed to unenroll user.', null, \core\output\notification::NOTIFY_ERROR);
+    echo json_encode(['success' => false, 'message' => 'Failed to unenroll user']);
 }
+exit;
 
 function unenroll_user_by_token($token_id) {
     global $DB;
@@ -57,3 +62,4 @@ function unenroll_user_by_token($token_id) {
 
     return true;
 }
+exit;

--- a/unenroll.php
+++ b/unenroll.php
@@ -1,0 +1,59 @@
+<?php
+require_once('../../config.php');
+require_login();
+require_capability('moodle/site:config', context_system::instance());
+
+$token_id = required_param('token_id', PARAM_INT);
+$sesskey = required_param('sesskey', PARAM_ALPHANUM);
+
+if (!confirm_sesskey($sesskey)) {
+    print_error('invalidsesskey');
+}
+
+// Call the unenroll function
+if (unenroll_user_by_token($token_id)) {
+    redirect(new moodle_url('/enrol/course_tokens/index.php'), 'User unenrolled successfully.', null, \core\output\notification::NOTIFY_SUCCESS);
+} else {
+    redirect(new moodle_url('/enrol/course_tokens/index.php'), 'Failed to unenroll user.', null, \core\output\notification::NOTIFY_ERROR);
+}
+
+function unenroll_user_by_token($token_id) {
+    global $DB;
+
+    // Get token details
+    $token = $DB->get_record('course_tokens', ['id' => $token_id], '*', MUST_EXIST);
+    if (!$token || empty($token->user_enrolments_id)) {
+        return false; // No enrollment found
+    }
+
+    // Get enrollment details
+    $enrolment = $DB->get_record('user_enrolments', ['id' => $token->user_enrolments_id], '*', MUST_EXIST);
+    if (!$enrolment) {
+        return false;
+    }
+
+    // Get enrol instance
+    $enrol = $DB->get_record('enrol', ['id' => $enrolment->enrolid], '*', MUST_EXIST);
+    if (!$enrol) {
+        return false;
+    }
+
+    // Get enrolment plugin
+    $enrol_plugin = enrol_get_plugin($enrol->enrol);
+    if (!$enrol_plugin) {
+        return false;
+    }
+
+    // Unenroll user
+    $enrol_plugin->unenrol_user($enrol, $enrolment->userid);
+
+    // Update token: Remove enrolment and used_by but **keep user_id**
+    $DB->update_record('course_tokens', [
+        'id' => $token_id,
+        'user_enrolments_id' => null, // Remove enrolment link
+        'used_by' => null, // Remove used_by reference
+        'used_on' => null, // Reset usage date
+    ]);
+
+    return true;
+}

--- a/unvoid_token.php
+++ b/unvoid_token.php
@@ -1,0 +1,9 @@
+<?php
+require_once('../../config.php');
+require_login();
+
+$token_id = required_param('token_id', PARAM_INT);
+
+$DB->execute("UPDATE {course_tokens} SET voided = 0, voided_at = NULL, voided_notes = NULL WHERE id = ?", [$token_id]);
+
+redirect(new moodle_url('/enrol/course_tokens/'), 'Token successfully unvoided.', null, \core\output\notification::NOTIFY_SUCCESS);

--- a/unvoid_token.php
+++ b/unvoid_token.php
@@ -4,6 +4,9 @@ require_login();
 
 $token_id = required_param('token_id', PARAM_INT);
 
+// Update the database to unvoid the token
 $DB->execute("UPDATE {course_tokens} SET voided = 0, voided_at = NULL, voided_notes = NULL WHERE id = ?", [$token_id]);
 
-redirect(new moodle_url('/enrol/course_tokens/'), 'Token successfully unvoided.', null, \core\output\notification::NOTIFY_SUCCESS);
+// Return JSON response instead of redirecting
+echo json_encode(["success" => true, "message" => "Token successfully unvoided."]);
+exit; // Ensure no extra output

--- a/use_token.php
+++ b/use_token.php
@@ -28,6 +28,14 @@ if (!$token) {
     exit();
 }
 
+// Prevent use of voided tokens
+if (!empty($token->voided)) {
+    echo $OUTPUT->header();
+    echo $OUTPUT->notification('This token has been voided and cannot be used.', 'error');
+    echo $OUTPUT->footer();
+    exit();
+}
+
 // Check if the token has already been used
 if (!empty($token->user_enrolments_id)) {
     echo $OUTPUT->header();

--- a/version.php
+++ b/version.php
@@ -2,7 +2,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_course_tokens';
-$plugin->version   = 2024120304;  // Updated to the new version YYYYMMDDXX
+$plugin->version   = 2024120306;  // Updated to match the latest upgrade step
 $plugin->requires  = 2020061500;  // Requires this Moodle version
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.3 (Build: 2024120304)';  // Updated to match the new version
+$plugin->release   = '1.3 (Build: 2024120306)';  // Updated to match the new version

--- a/view_tokens.php
+++ b/view_tokens.php
@@ -16,7 +16,7 @@ $sql = "SELECT t.*, u.email as enrolled_user_email
         FROM {course_tokens} t
         LEFT JOIN {user_enrolments} ue ON t.user_enrolments_id = ue.id
         LEFT JOIN {user} u ON ue.userid = u.id
-        WHERE t.user_id = ?
+        WHERE t.user_id = ? AND t.voided_at IS NULL
         ORDER BY t.id DESC";
 
 $tokens = $DB->get_records_sql($sql, [$USER->id]);

--- a/void_token.php
+++ b/void_token.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once('../../config.php');
+require_login();
+require_capability('moodle/site:config', context_system::instance());
+
+$tokenid = required_param('tokenid', PARAM_INT);
+$void_notes = required_param('void_notes', PARAM_TEXT);
+$sesskey = required_param('sesskey', PARAM_ALPHANUM);
+
+if (!confirm_sesskey($sesskey)) {
+    echo json_encode(['success' => false, 'message' => 'Invalid session key.']);
+    exit;
+}
+
+// Get current timestamp
+$voided_at = time();
+
+// Get token details
+$token = $DB->get_record('course_tokens', ['id' => $tokenid], '*', MUST_EXIST);
+
+if ($token->used_on) { // If token is used, unenroll the user
+    require_once(__DIR__ . '/unenroll.php');
+
+    if (!unenroll_user_by_token($tokenid)) {
+        echo json_encode(['success' => false, 'message' => 'Failed to unenroll the user.']);
+        exit;
+    }
+}
+
+// Update the token as voided
+$DB->update_record('course_tokens', [
+    'id' => $tokenid,
+    'voided' => 1,
+    'voided_at' => $voided_at,
+    'voided_notes' => $void_notes
+]);
+
+echo json_encode(['success' => true, 'message' => 'Token voided successfully.']);
+exit;

--- a/void_token.php
+++ b/void_token.php
@@ -13,26 +13,14 @@ if (!confirm_sesskey($sesskey)) {
     exit;
 }
 
-// Get current timestamp
-$voided_at = time();
-
 // Get token details
 $token = $DB->get_record('course_tokens', ['id' => $tokenid], '*', MUST_EXIST);
-
-if ($token->used_on) { // If token is used, unenroll the user
-    require_once(__DIR__ . '/unenroll.php');
-
-    if (!unenroll_user_by_token($tokenid)) {
-        echo json_encode(['success' => false, 'message' => 'Failed to unenroll the user.']);
-        exit;
-    }
-}
 
 // Update the token as voided
 $DB->update_record('course_tokens', [
     'id' => $tokenid,
     'voided' => 1,
-    'voided_at' => $voided_at,
+    'voided_at' => time(),
     'voided_notes' => $void_notes
 ]);
 


### PR DESCRIPTION
This PR is made for https://github.com/modern-training-solutions/learn.PacificMedicalTraining.com/issues/160

1. Added `voided_at` and `voided_notes` columns in the course tokens table.
2. Changed `voided` column from `longblob` to `tinyint(1)`, default value is "0", means not voided.
3. Added unenroll button on the index page, shown only for tokens that are used.
4. Added `unenroll.php`. This unenrolls the student from the course and remove data from `user_enrollments_id`(Enrolled user's id), `used_on` and `used_by` information. Purchaser's information `user_id` is kept intact. After unenroll token is not voided, and can be used again for any user.
5. Added `void_token.php` to void tokens, admin can void tokens from index page, a tooltip is shown as warning and then a modal is shown to confirm, then token is voided.
6. Updated `use_token.php` to not use voided tokens.
7. Added `unvoide_token.php` to unvoid a token to make it usable again. Tooltip and modal is shown, same as voiding.
8. Updated `view_tokens.php` to not show voided tokens to users.
9. If a token is used already, while voiding unenroll the user from the course.